### PR TITLE
Add display of binary outputs

### DIFF
--- a/inspector/gradle.properties
+++ b/inspector/gradle.properties
@@ -1,3 +1,3 @@
-version=0.1.0
+version=0.1.1
 group=com.jakeout
 artifact=gradle-inspector

--- a/inspector/src/main/kotlin/com/jakeout/gradle/inspector/InspectorGradleListener.kt
+++ b/inspector/src/main/kotlin/com/jakeout/gradle/inspector/InspectorGradleListener.kt
@@ -27,7 +27,7 @@ public class InspectorGradleListener(val config: InspectorConfig, val project: P
     companion object {
         val SHOW_INSPECTION_PROPERTY = "showInspection"
         val COMPARE_LAST_BUILD_PROPERTY = "compareLastBuild"
-        val PROFILE_PATH = "buildProfile"
+        val PROFILE_PATH = ".buildProfile"
         val DIFF_INCREMENTAL = "diffIncremental"
         val DIFF_REPORT = "report"
         val PROFILE_PATH_COMPARE = "buildProfileCompare"
@@ -153,7 +153,7 @@ public class InspectorGradleListener(val config: InspectorConfig, val project: P
             makeFile("font/fonts/fontawesome-webfont.woff2")
 
             val subprojectsByFile = HashMap<String, File>()
-            for (subProj in project.getSubprojects()) {
+            for (subProj in project.getChildProjects().values()) {
                 val plugin = subProj.getPlugins().findPlugin(javaClass<InspectorPlugin>()) as InspectorPlugin
                 val listener = plugin.listener
                 if (listener != null) {
@@ -209,7 +209,6 @@ public class InspectorGradleListener(val config: InspectorConfig, val project: P
         Files.copy(
                 this.javaClass.getClassLoader().getResourceAsStream(path),
                 file)
-
     }
 
     override fun buildStarted(gradle: Gradle) {

--- a/inspector/src/main/kotlin/com/jakeout/gradle/inspector/tasks/model/TaskDiffResults.kt
+++ b/inspector/src/main/kotlin/com/jakeout/gradle/inspector/tasks/model/TaskDiffResults.kt
@@ -1,6 +1,9 @@
 package com.jakeout.gradle.inspector.tasks.model
 
 import com.zutubi.diff.PatchFile
+import java.util.*
+
+public enum class FileState { ADDED, DELETED, CHANGED, UNKNOWN }
 
 data class TaskDiffResults(
         val filesTouched: Int,
@@ -8,4 +11,5 @@ data class TaskDiffResults(
         val hunksRemoved: Int,
         val anyUndeclaredChanges: Boolean,
         val changesByType: Map<String, Int>,
-        val patchFile: PatchFile?)
+        val patchFile: PatchFile?,
+        val binaries: Map<String, FileState>)


### PR DESCRIPTION
- Fix a bug where all subproject, not just child projects, were shown, in the link hierarchy of a project.

- Move to .buildProfile, hidden folder, to not mess up git repose as much.

- The current display is a little ugly, will iterate.