### PR TITLE
Fix issue where the plugin { } syntax failed due to an attempt to cas…

### DIFF
--- a/inspector/src/main/kotlin/com/jakeout/gradle/inspector/InspectorConfig.kt
+++ b/inspector/src/main/kotlin/com/jakeout/gradle/inspector/InspectorConfig.kt
@@ -21,4 +21,5 @@ data class InspectorConfig(
     fun taskDir(task: Task) = File(incrementalDir, task.nameString())
     fun compareTaskDir(task: Task) = File(compareIncrementalDir, task.nameString())
     fun Task.nameString() = getName().replace(":", ".")
+    fun index() = File(reportDir, "index.html")
 }

--- a/inspector/src/main/kotlin/com/jakeout/gradle/inspector/InspectorPluginExtension.kt
+++ b/inspector/src/main/kotlin/com/jakeout/gradle/inspector/InspectorPluginExtension.kt
@@ -1,0 +1,8 @@
+package com.jakeout.gradle.inspector
+
+import java.io.File
+
+public open class InspectorPluginExtension {
+
+    public open var index: File? = null
+}


### PR DESCRIPTION
…t an object out of the class path.

Use extension objects to store active state.
